### PR TITLE
Different badge color by type of release

### DIFF
--- a/add-jenkins-badge.groovy
+++ b/add-jenkins-badge.groovy
@@ -25,7 +25,8 @@ if (projectName != null && version != null) {
 
 	loader = jenkins.model.Jenkins.getInstance().getPluginManager().uberClassLoader
 	clazz = loader.loadClass("org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildAction")
-	action = clazz.createShortText(version)
+	background = (version.matches("^[^A-Za-z]+$")?"#00FF00":version.matches("^.+?\\d$")?"#FFAA00":"#FFFF00");
+	action = clazz.createShortText(version, "#000000", background,"1px", "#000000")
 
 	build.getActions().add(action)
 


### PR DESCRIPTION
Use green, yellow or orange badges 
for stable, final or daily builds 
e.g. 1.47, 1.47a or 1.47a6
